### PR TITLE
fix indentation in four_sequence_exists

### DIFF
--- a/four_in_a_row/board.py
+++ b/four_in_a_row/board.py
@@ -90,7 +90,9 @@ class Board:
         self.state = [[Color.EMPTY for _ in range(0, self.columns)] for _ in range(0, self.rows)]
 
     @classmethod
-    def read(cls, rows, columns, input_board):
+    def read(cls, input_board):
+        rows = len(input_board)
+        columns = len(input_board[0])
         board_state = []
         for r in range(rows - 1, -1, -1):
             board_state.append(input_board[r])

--- a/four_in_a_row/logic.py
+++ b/four_in_a_row/logic.py
@@ -11,8 +11,8 @@ def four_sequence_exists(discs_vector):
     for i in range(1, len(discs_vector)):
         if discs_vector[i] == discs_vector[i - 1] and not (discs_vector[i] is Color.EMPTY.value):
             current_seq += 1
-        if current_seq > longest_seq:
-            longest_seq = current_seq
+            if current_seq > longest_seq:
+                longest_seq = current_seq
         else:
             current_seq = 1
     return longest_seq == 4

--- a/four_in_a_row/tests.py
+++ b/four_in_a_row/tests.py
@@ -43,6 +43,15 @@ def test_winning_boards():
         },
         {
             'board_state':
+                [[0, 0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0, 0],
+                 [0, 0, 0, 0, 0, 0, 0],
+                 [1, 1, 0, 1, 1, 1, 1]],
+            'pos_r': 0,
+            'pos_c': 3
+        },
+        {
+            'board_state':
                 [[0, 0, 0, 0, 0],
                  [0, 0, 0, 0, 0],
                  [0, 0, 0, 0, 0],
@@ -88,7 +97,7 @@ def test_winning_boards():
         }
     ]
     for entry in winning_boards_data:
-        board = Board.read(4, 5, entry['board_state'])
+        board = Board.read(entry['board_state'])
         assert (is_win(board, entry['pos_r'], entry['pos_c']) is True)
 
 
@@ -150,7 +159,7 @@ def test_no_win_boards():
         }
     ]
     for entry in winning_boards_data:
-        board = Board.read(4, 5, entry['board_state'])
+        board = Board.read(entry['board_state'])
         assert (is_win(board, entry['pos_r'], entry['pos_c']) is False)
 
 


### PR DESCRIPTION
Also updated `Board.read` so it gets the board dimension from the input board, so we don't need to pass it - it makes the test code simpler.